### PR TITLE
set dev option correctly when in non-debug mode

### DIFF
--- a/Source/CDControl.m
+++ b/Source/CDControl.m
@@ -75,13 +75,12 @@
             // case they access the options themselves to add additional properties like
             // "required" or "defaultValue".
             [control debugOptions:opt];
-
+#ifndef DEBUG
             // If not in Xcode debug mode, force the --dev option to be disabled.
             if ([opt.name isEqualToStringCaseInsensitive:@"dev"]) {
-#ifndef DEBUG
-                opt.provided(YES).rawValue(@"NO");
-#endif
+                opt.provided(NO).rawValue(@"NO");
             }
+#endif
         };
     }
     return self;


### PR DESCRIPTION
As far as I can tell, this line was intended to set the "dev" option's provided value to NO instead of YES.  The previous code caused release builds of cocoadialog to fail silently.